### PR TITLE
feat: expandable card detail with per-side schedule info

### DIFF
--- a/src/components/flashcards/CardList.tsx
+++ b/src/components/flashcards/CardList.tsx
@@ -1,4 +1,16 @@
+import { useState } from 'react';
 import type { CardWithSides } from '../../services/flashcardCardService';
+import type { FlashcardCardSide } from '../../lib/supabase';
+import {
+  getCardScheduleInfo,
+  getStatusBadgeStyle,
+  getStatusLabel,
+  getEaseInfo,
+  formatDueDate,
+  getSideLabel,
+  getSideStatus,
+  formatInterval,
+} from '../../lib/flashcardScheduleUtils';
 
 interface CardListProps {
   cards: CardWithSides[];
@@ -39,6 +51,38 @@ function truncateText(text: string, maxLength: number): string {
   return text.substring(0, maxLength).trim() + '...';
 }
 
+function SideDetail({ side, cardType }: { side: FlashcardCardSide; cardType: string }) {
+  const sideStatus = getSideStatus(side);
+  const sideEase = getEaseInfo(side.ease_factor);
+  const sideDueDate = side.next_review ? new Date(side.next_review) : null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <span className="text-sm font-medium text-gray-700">
+        {getSideLabel(cardType as 'basic' | 'reversible' | 'cloze', side.side_index)}
+      </span>
+      <span
+        className={`px-1.5 py-0.5 text-xs font-medium rounded ${getStatusBadgeStyle(sideStatus)}`}
+      >
+        {getStatusLabel(sideStatus)}
+      </span>
+      <span className="text-xs text-gray-500">
+        {formatDueDate(sideDueDate, sideStatus)}
+      </span>
+      {sideStatus !== 'new' && (
+        <>
+          <span className={`text-xs ${sideEase.colorClass}`}>
+            {sideEase.label}
+          </span>
+          <span className="text-xs text-gray-400">
+            {formatInterval(side.interval_days)}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
 export function CardList({
   cards,
   selectedCardIds,
@@ -46,94 +90,157 @@ export function CardList({
   onEditCard,
   onDeleteCard,
 }: CardListProps) {
+  const [expandedCardId, setExpandedCardId] = useState<string | null>(null);
+
   return (
     <div className="space-y-2">
-      {cards.map((card) => (
-        <div
-          key={card.id}
-          className={`bg-white rounded-lg border ${
-            selectedCardIds.has(card.id)
-              ? 'border-amber-300 ring-2 ring-amber-100'
-              : 'border-gray-200'
-          } hover:shadow-sm transition-shadow`}
-        >
-          <div className="flex items-start p-4">
-            {/* Checkbox */}
-            <label className="flex items-center cursor-pointer mr-3 pt-1">
-              <input
-                type="checkbox"
-                checked={selectedCardIds.has(card.id)}
-                onChange={(e) => onCardSelect(card.id, e.target.checked)}
-                className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
-              />
-            </label>
+      {cards.map((card) => {
+        const isExpanded = expandedCardId === card.id;
+        return (
+          <div
+            key={card.id}
+            className={`bg-white rounded-lg border ${
+              selectedCardIds.has(card.id)
+                ? 'border-amber-300 ring-2 ring-amber-100'
+                : 'border-gray-200'
+            } hover:shadow-sm transition-shadow`}
+          >
+            <div className="flex items-start p-4">
+              {/* Checkbox */}
+              <label className="flex items-center cursor-pointer mr-3 pt-1">
+                <input
+                  type="checkbox"
+                  checked={selectedCardIds.has(card.id)}
+                  onChange={(e) => onCardSelect(card.id, e.target.checked)}
+                  className="w-4 h-4 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
+                />
+              </label>
 
-            {/* Card content */}
-            <div
-              className="flex-1 min-w-0 cursor-pointer"
-              onClick={() => onEditCard(card)}
-            >
-              <div className="flex items-center gap-2 mb-2">
-                <span
-                  className={`px-2 py-0.5 text-xs font-medium rounded ${getCardTypeColor(
-                    card.card_type
-                  )}`}
+              {/* Card content */}
+              <div
+                className="flex-1 min-w-0 cursor-pointer"
+                onClick={() => setExpandedCardId(isExpanded ? null : card.id)}
+              >
+                {(() => {
+                  const scheduleInfo = getCardScheduleInfo(card.sides);
+                  const easeInfo = getEaseInfo(scheduleInfo.averageEase);
+                  return (
+                    <>
+                      <div className="flex flex-wrap items-center gap-2 mb-2">
+                        <span
+                          className={`px-2 py-0.5 text-xs font-medium rounded ${getCardTypeColor(
+                            card.card_type
+                          )}`}
+                        >
+                          {getCardTypeLabel(card.card_type)}
+                        </span>
+                        <span className="text-xs text-gray-400">
+                          {card.sides.length} side{card.sides.length !== 1 ? 's' : ''}
+                        </span>
+                        <span
+                          className={`px-2 py-0.5 text-xs font-medium rounded ${getStatusBadgeStyle(
+                            scheduleInfo.status
+                          )}`}
+                        >
+                          {getStatusLabel(scheduleInfo.status)}
+                        </span>
+                      </div>
+
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium text-gray-900">
+                          {truncateText(card.front, 100)}
+                        </p>
+                        <p className="text-sm text-gray-500">
+                          {truncateText(card.back, 80)}
+                        </p>
+                      </div>
+
+                      {/* Schedule info row */}
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 pt-2 border-t border-gray-100 text-xs">
+                        <span className="text-gray-500">
+                          {formatDueDate(scheduleInfo.earliestDue, scheduleInfo.status)}
+                        </span>
+                        {scheduleInfo.status !== 'new' && (
+                          <span className={easeInfo.colorClass}>
+                            {easeInfo.label}
+                          </span>
+                        )}
+                        {card.sides.length > 1 && (
+                          <span className="text-gray-400">
+                            {scheduleInfo.sidesLearned}/{scheduleInfo.totalSides} learned
+                          </span>
+                        )}
+                      </div>
+                    </>
+                  );
+                })()}
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-1 ml-2">
+                <button
+                  onClick={() => onEditCard(card)}
+                  className="p-2 text-gray-400 hover:text-gray-600 rounded-lg transition-colors touch-manipulation"
+                  aria-label="Edit card"
                 >
-                  {getCardTypeLabel(card.card_type)}
-                </span>
-                <span className="text-xs text-gray-400">
-                  {card.sides.length} side{card.sides.length !== 1 ? 's' : ''}
-                </span>
-              </div>
-
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-gray-900">
-                  {truncateText(card.front, 100)}
-                </p>
-                <p className="text-sm text-gray-500">
-                  {truncateText(card.back, 80)}
-                </p>
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => {
+                    if (window.confirm('Delete this card?')) {
+                      onDeleteCard(card.id);
+                    }
+                  }}
+                  className="p-2 text-gray-400 hover:text-red-600 rounded-lg transition-colors touch-manipulation"
+                  aria-label="Delete card"
+                >
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
 
-            {/* Actions */}
-            <div className="flex items-center gap-1 ml-2">
-              <button
-                onClick={() => onEditCard(card)}
-                className="p-2 text-gray-400 hover:text-gray-600 rounded-lg transition-colors touch-manipulation"
-                aria-label="Edit card"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                  />
-                </svg>
-              </button>
-              <button
-                onClick={() => {
-                  if (window.confirm('Delete this card?')) {
-                    onDeleteCard(card.id);
-                  }
-                }}
-                className="p-2 text-gray-400 hover:text-red-600 rounded-lg transition-colors touch-manipulation"
-                aria-label="Delete card"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-              </button>
-            </div>
+            {/* Expanded per-side detail section */}
+            {isExpanded && (
+              <div className="px-4 pb-4 pt-0 ml-10 border-t border-gray-100">
+                <div className="mt-3 space-y-2">
+                  {card.sides
+                    .slice()
+                    .sort((a, b) => a.side_index - b.side_index)
+                    .map((side) => (
+                      <SideDetail
+                        key={side.id}
+                        side={side}
+                        cardType={card.card_type}
+                      />
+                    ))}
+                </div>
+                <div className="mt-3 pt-3 border-t border-gray-100">
+                  <button
+                    onClick={() => onEditCard(card)}
+                    className="px-4 py-2 text-sm font-medium text-amber-700 bg-amber-50 hover:bg-amber-100 rounded-lg transition-colors touch-manipulation"
+                  >
+                    Edit Card
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/lib/flashcardScheduleUtils.ts
+++ b/src/lib/flashcardScheduleUtils.ts
@@ -1,0 +1,252 @@
+/**
+ * Utility functions for flashcard schedule display
+ * Calculates aggregate status and formatting for card sides
+ */
+
+import type { FlashcardCardSide, FlashcardCardType } from './supabase';
+
+export type CardStatus = 'new' | 'due' | 'overdue' | 'scheduled';
+
+export interface CardScheduleInfo {
+  status: CardStatus;
+  earliestDue: Date | null;
+  averageEase: number;
+  sidesLearned: number;
+  totalSides: number;
+}
+
+/**
+ * Calculate aggregate schedule info from card sides
+ * Uses worst-case (earliest due, lowest ease) for multi-side cards
+ */
+export function getCardScheduleInfo(sides: FlashcardCardSide[]): CardScheduleInfo {
+  if (sides.length === 0) {
+    return {
+      status: 'new',
+      earliestDue: null,
+      averageEase: 2.5,
+      sidesLearned: 0,
+      totalSides: 0,
+    };
+  }
+
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const endOfToday = new Date();
+  endOfToday.setHours(23, 59, 59, 999);
+
+  let earliestDue: Date | null = null;
+  let totalEase = 0;
+  let sidesLearned = 0;
+  let hasNewSide = false;
+  let hasDueSide = false;
+  let hasOverdueSide = false;
+
+  for (const side of sides) {
+    totalEase += side.ease_factor;
+
+    if (side.repetitions > 0) {
+      sidesLearned++;
+    }
+
+    if (side.next_review === null) {
+      hasNewSide = true;
+    } else {
+      const dueDate = new Date(side.next_review);
+
+      // Track earliest due date
+      if (earliestDue === null || dueDate < earliestDue) {
+        earliestDue = dueDate;
+      }
+
+      // Check status: due today (including later today) counts as due
+      if (dueDate < oneDayAgo) {
+        hasOverdueSide = true;
+      } else if (dueDate <= endOfToday) {
+        hasDueSide = true;
+      }
+    }
+  }
+
+  // Determine overall status (worst case wins)
+  let status: CardStatus;
+  if (hasOverdueSide) {
+    status = 'overdue';
+  } else if (hasDueSide) {
+    status = 'due';
+  } else if (hasNewSide && sidesLearned === 0) {
+    status = 'new';
+  } else if (earliestDue === null) {
+    status = 'new';
+  } else {
+    status = 'scheduled';
+  }
+
+  return {
+    status,
+    earliestDue,
+    averageEase: totalEase / sides.length,
+    sidesLearned,
+    totalSides: sides.length,
+  };
+}
+
+/**
+ * Get Tailwind classes for status badge
+ */
+export function getStatusBadgeStyle(status: CardStatus): string {
+  switch (status) {
+    case 'new':
+      return 'bg-blue-100 text-blue-700';
+    case 'due':
+      return 'bg-amber-100 text-amber-700';
+    case 'overdue':
+      return 'bg-red-100 text-red-700';
+    case 'scheduled':
+      return 'bg-green-100 text-green-700';
+  }
+}
+
+/**
+ * Get status label for display
+ */
+export function getStatusLabel(status: CardStatus): string {
+  switch (status) {
+    case 'new':
+      return 'New';
+    case 'due':
+      return 'Due';
+    case 'overdue':
+      return 'Overdue';
+    case 'scheduled':
+      return 'Scheduled';
+  }
+}
+
+/**
+ * Get ease interpretation with label and color
+ */
+export function getEaseInfo(ease: number): { label: string; colorClass: string } {
+  if (ease >= 2.5) {
+    return { label: 'Easy', colorClass: 'text-green-600' };
+  } else if (ease >= 2.0) {
+    return { label: 'Normal', colorClass: 'text-gray-500' };
+  } else if (ease >= 1.5) {
+    return { label: 'Hard', colorClass: 'text-amber-600' };
+  } else {
+    return { label: 'Very Hard', colorClass: 'text-red-600' };
+  }
+}
+
+/**
+ * Get the number of calendar days between two dates in local timezone.
+ * Returns negative if date is in the past, positive if in the future.
+ */
+function calendarDayDiff(from: Date, to: Date): number {
+  const fromDay = new Date(from.getFullYear(), from.getMonth(), from.getDate());
+  const toDay = new Date(to.getFullYear(), to.getMonth(), to.getDate());
+  return Math.round((toDay.getTime() - fromDay.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Format due date for display
+ */
+export function formatDueDate(date: Date | null, status: CardStatus): string {
+  if (date === null || status === 'new') {
+    return 'Never studied';
+  }
+
+  const now = new Date();
+  const daysDiff = calendarDayDiff(now, date);
+
+  if (status === 'overdue') {
+    const overdueDays = Math.abs(daysDiff);
+    if (overdueDays === 0) {
+      return 'Due today';
+    } else if (overdueDays === 1) {
+      return '1 day overdue';
+    } else {
+      return `${overdueDays} days overdue`;
+    }
+  }
+
+  if (status === 'due') {
+    return 'Due today';
+  }
+
+  // Scheduled
+  if (daysDiff === 0) {
+    return 'Due today';
+  } else if (daysDiff === 1) {
+    return 'Due tomorrow';
+  } else if (daysDiff < 7) {
+    return `Due in ${daysDiff} days`;
+  } else if (daysDiff < 30) {
+    const weeks = Math.floor(daysDiff / 7);
+    return `Due in ${weeks} week${weeks > 1 ? 's' : ''}`;
+  } else {
+    const months = Math.floor(daysDiff / 30);
+    return `Due in ${months} month${months > 1 ? 's' : ''}`;
+  }
+}
+
+/**
+ * Get a human-readable label for a card side based on card type and index
+ */
+export function getSideLabel(cardType: FlashcardCardType, sideIndex: number): string {
+  switch (cardType) {
+    case 'basic':
+      return 'Front \u2192 Back';
+    case 'reversible':
+      return sideIndex === 0 ? 'Front \u2192 Back' : 'Back \u2192 Front';
+    case 'cloze':
+      return `Cloze ${sideIndex + 1}`;
+    default:
+      return `Side ${sideIndex + 1}`;
+  }
+}
+
+/**
+ * Get the schedule status for an individual card side
+ */
+export function getSideStatus(side: FlashcardCardSide): CardStatus {
+  if (side.next_review === null) {
+    return 'new';
+  }
+
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const endOfToday = new Date();
+  endOfToday.setHours(23, 59, 59, 999);
+  const dueDate = new Date(side.next_review);
+
+  if (dueDate < oneDayAgo) {
+    return 'overdue';
+  } else if (dueDate <= endOfToday) {
+    return 'due';
+  } else {
+    return 'scheduled';
+  }
+}
+
+/**
+ * Format an interval in days to a human-readable string
+ */
+export function formatInterval(days: number): string {
+  if (days === 0) {
+    return 'New';
+  } else if (days === 1) {
+    return '1 day';
+  } else if (days < 7) {
+    return `${days} days`;
+  } else if (days < 30) {
+    const weeks = Math.floor(days / 7);
+    return weeks === 1 ? '1 week' : `${weeks} weeks`;
+  } else if (days < 365) {
+    const months = Math.floor(days / 30);
+    return months === 1 ? '1 month' : `${months} months`;
+  } else {
+    const years = Math.floor(days / 365);
+    return years === 1 ? '1 year' : `${years} years`;
+  }
+}


### PR DESCRIPTION
## Summary
- Clicking a card in the Edit view now expands it inline to show per-side schedule details (status, due date, ease, interval) instead of opening the edit modal
- Pencil icon still opens the edit modal directly; expanded view includes an "Edit Card" button
- Added `getSideLabel`, `getSideStatus`, and `formatInterval` helpers to `flashcardScheduleUtils.ts`
- Fixed due card query to include cards due later today (end-of-day cutoff instead of current time)

## Test plan
- [ ] Edit view: click card content → expands with per-side details; click again → collapses
- [ ] Pencil icon → opens edit modal (not expand)
- [ ] Reversible cards show 2 sides ("Front → Back", "Back → Front") with independent schedules
- [ ] Cloze cards show N sides labeled "Cloze 1", "Cloze 2", etc.
- [ ] Basic cards show single side detail
- [ ] "Edit Card" button in expanded section opens modal
- [ ] Cards due later today now appear in quiz
- [ ] Mobile responsive — detail section renders correctly on small viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)