### PR TITLE
feat: add debt/loan tracker to expense tracker

### DIFF
--- a/src/components/expense-tracker/DebtTracker.tsx
+++ b/src/components/expense-tracker/DebtTracker.tsx
@@ -1,0 +1,893 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DebtService } from '../../services/debtService';
+import { UserContactService } from '../../services/userContactService';
+import { TransactionService } from '../../services/transactionService';
+import { formatDate } from '../../lib/dateUtils';
+import { formatCurrency, SUPPORTED_CURRENCIES, CURRENCY_INFO } from '../../lib/currencies';
+import { ExchangeRateService } from '../../services/exchangeRateService';
+import { useUserSettings } from '../../hooks/useUserSettings';
+import type { DebtWithPayments, ContactDebtSummary, DebtStatus } from '../../services/debtService';
+import type { UserContact, UserExpenseCategory, UserAccount } from '../../lib/supabase';
+import type { SupportedCurrency } from '../../lib/currencies';
+
+type ViewMode = 'list' | 'summary';
+type FilterType = 'all' | 'owed_to_me' | 'owed_by_me';
+type FilterStatus = 'all' | 'pending' | 'partial' | 'settled';
+
+const STATUS_COLORS: Record<DebtStatus, string> = {
+  pending: 'bg-amber-100 text-amber-800',
+  partial: 'bg-blue-100 text-blue-800',
+  settled: 'bg-green-100 text-green-800',
+};
+
+export function DebtTracker() {
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [debts, setDebts] = useState<DebtWithPayments[]>([]);
+  const [contacts, setContacts] = useState<UserContact[]>([]);
+  const [summary, setSummary] = useState<ContactDebtSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const { defaultCurrency } = useUserSettings();
+
+  // Filters
+  const [filterType, setFilterType] = useState<FilterType>('all');
+  const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
+
+  // Expanded debt (show payments)
+  const [expandedDebtId, setExpandedDebtId] = useState<string | null>(null);
+
+  // Add debt modal
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [debtForm, setDebtForm] = useState({
+    type: 'owed_to_me' as 'owed_to_me' | 'owed_by_me',
+    contactId: '',
+    title: '',
+    description: '',
+    amount: '',
+    currency: (defaultCurrency || 'USD') as string,
+    createTransaction: false,
+    categoryId: '',
+    accountId: '',
+    transactionDate: new Date().toISOString().split('T')[0],
+  });
+
+  // Transaction selectors data
+  const [categories, setCategories] = useState<UserExpenseCategory[]>([]);
+  const [accounts, setAccounts] = useState<UserAccount[]>([]);
+
+  // Add payment form
+  const [paymentForm, setPaymentForm] = useState({
+    amount: '',
+    paymentDate: new Date().toISOString().split('T')[0],
+    note: '',
+  });
+  const [addingPaymentForDebt, setAddingPaymentForDebt] = useState<string | null>(null);
+
+  // Currency conversion
+  const [showConversion, setShowConversion] = useState(false);
+  const [convertFrom, setConvertFrom] = useState<SupportedCurrency>('USD');
+  const [convertAmount, setConvertAmount] = useState<number>(0);
+  const [convertPreview, setConvertPreview] = useState('');
+
+  const loadData = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError('');
+      const [debtsData, contactsData] = await Promise.all([
+        DebtService.getDebts(),
+        UserContactService.getContacts(),
+      ]);
+      setDebts(debtsData);
+      setContacts(contactsData);
+
+      if (viewMode === 'summary') {
+        const summaryData = await DebtService.getDebtSummaryByContact();
+        setSummary(summaryData);
+      }
+    } catch (err) {
+      console.error('Error loading debt data:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load data');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [viewMode]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Update currency when default changes
+  useEffect(() => {
+    if (defaultCurrency) {
+      setDebtForm(prev => ({ ...prev, currency: defaultCurrency }));
+    }
+  }, [defaultCurrency]);
+
+  const loadTransactionData = async () => {
+    try {
+      const [cats, accts] = await Promise.all([
+        TransactionService.getExpenseCategories(),
+        TransactionService.getUserAccounts(),
+      ]);
+      setCategories(cats);
+      setAccounts(accts);
+    } catch (err) {
+      console.error('Error loading transaction data:', err);
+    }
+  };
+
+  const filteredDebts = debts.filter(debt => {
+    if (filterType !== 'all' && debt.type !== filterType) return false;
+    if (filterStatus !== 'all' && debt.status !== filterStatus) return false;
+    return true;
+  });
+
+  const getContactName = (contactId: string) => {
+    return contacts.find(c => c.id === contactId)?.name || 'Unknown';
+  };
+
+  const handleConvert = async () => {
+    if (convertAmount <= 0) return;
+    try {
+      const converted = await ExchangeRateService.convert(
+        convertAmount,
+        convertFrom,
+        debtForm.currency as SupportedCurrency,
+      );
+      if (converted !== null) {
+        setDebtForm(prev => ({ ...prev, amount: (Math.round(converted * 100) / 100).toString() }));
+        const rate = await ExchangeRateService.convert(1, convertFrom, debtForm.currency as SupportedCurrency);
+        setConvertPreview(`1 ${convertFrom} = ${rate !== null ? rate.toFixed(4) : '?'} ${debtForm.currency}`);
+      }
+    } catch (err) {
+      console.error('Conversion failed:', err);
+      setError('Currency conversion failed. Try again later.');
+    }
+  };
+
+  const handleCreateDebt = async () => {
+    try {
+      setError('');
+      const amount = parseFloat(debtForm.amount);
+      if (isNaN(amount) || amount <= 0) {
+        setError('Amount must be a positive number');
+        return;
+      }
+
+      const transactionData = debtForm.createTransaction
+        ? {
+            categoryId: debtForm.categoryId,
+            accountId: debtForm.accountId,
+            transactionDate: debtForm.transactionDate,
+          }
+        : undefined;
+
+      await DebtService.createDebtOfflineAware(
+        {
+          contactId: debtForm.contactId,
+          type: debtForm.type,
+          title: debtForm.title,
+          description: debtForm.description || undefined,
+          amount,
+          currency: debtForm.currency,
+        },
+        transactionData
+      );
+
+      setShowAddModal(false);
+      resetDebtForm();
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create debt');
+    }
+  };
+
+  const resetDebtForm = () => {
+    setDebtForm({
+      type: 'owed_to_me',
+      contactId: '',
+      title: '',
+      description: '',
+      amount: '',
+      currency: (defaultCurrency || 'USD') as string,
+      createTransaction: false,
+      categoryId: '',
+      accountId: '',
+      transactionDate: new Date().toISOString().split('T')[0],
+    });
+    setShowConversion(false);
+    setConvertFrom('USD');
+    setConvertAmount(0);
+    setConvertPreview('');
+  };
+
+  const handleDeleteDebt = async (debtId: string) => {
+    if (!confirm('Are you sure you want to delete this debt and all its payments?')) return;
+    try {
+      setError('');
+      await DebtService.deleteDebt(debtId);
+      setExpandedDebtId(null);
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete debt');
+    }
+  };
+
+  const handleAddPayment = async (debtId: string, directAmount?: number) => {
+    try {
+      setError('');
+      const amount = directAmount ?? parseFloat(paymentForm.amount);
+      if (isNaN(amount) || amount <= 0) {
+        setError('Payment amount must be a positive number');
+        return;
+      }
+
+      await DebtService.addPayment(debtId, {
+        amount,
+        paymentDate: directAmount ? new Date().toISOString().split('T')[0] : paymentForm.paymentDate,
+        note: directAmount ? 'Full settlement' : (paymentForm.note || undefined),
+      });
+
+      setPaymentForm({
+        amount: '',
+        paymentDate: new Date().toISOString().split('T')[0],
+        note: '',
+      });
+      setAddingPaymentForDebt(null);
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add payment');
+    }
+  };
+
+  const handleDeletePayment = async (paymentId: string) => {
+    if (!confirm('Are you sure you want to delete this payment?')) return;
+    try {
+      setError('');
+      await DebtService.deletePayment(paymentId);
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete payment');
+    }
+  };
+
+  const openAddModal = () => {
+    resetDebtForm();
+    setShowAddModal(true);
+    loadTransactionData();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-600 mx-auto mb-4"></div>
+            <p className="text-gray-600">Loading debts...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+      {error && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <h2 className="text-2xl font-bold text-gray-900">Debts</h2>
+        <div className="flex items-center gap-3">
+          {/* View Toggle */}
+          <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+            <button
+              onClick={() => setViewMode('list')}
+              className={`px-4 py-2 text-sm font-medium touch-manipulation min-h-[44px] ${
+                viewMode === 'list'
+                  ? 'bg-emerald-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              List
+            </button>
+            <button
+              onClick={() => setViewMode('summary')}
+              className={`px-4 py-2 text-sm font-medium touch-manipulation min-h-[44px] ${
+                viewMode === 'summary'
+                  ? 'bg-emerald-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              Summary
+            </button>
+          </div>
+          <button
+            onClick={openAddModal}
+            className="bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors duration-200 text-sm font-medium touch-manipulation min-h-[44px]"
+          >
+            Add Debt
+          </button>
+        </div>
+      </div>
+
+      {viewMode === 'list' ? (
+        <>
+          {/* Filters */}
+          <div className="flex flex-wrap gap-2">
+            {/* Type filters */}
+            {([['all', 'All'], ['owed_to_me', 'Owed to me'], ['owed_by_me', 'I owe']] as const).map(([value, label]) => (
+              <button
+                key={value}
+                onClick={() => setFilterType(value)}
+                className={`px-3 py-2 rounded-lg text-sm font-medium touch-manipulation min-h-[44px] ${
+                  filterType === value
+                    ? 'bg-emerald-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+            <div className="w-px bg-gray-300 mx-1 self-stretch"></div>
+            {/* Status filters */}
+            {([['all', 'All status'], ['pending', 'Pending'], ['partial', 'Partial'], ['settled', 'Settled']] as const).map(([value, label]) => (
+              <button
+                key={value}
+                onClick={() => setFilterStatus(value)}
+                className={`px-3 py-2 rounded-lg text-sm font-medium touch-manipulation min-h-[44px] ${
+                  filterStatus === value
+                    ? 'bg-emerald-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {/* Debt List */}
+          {filteredDebts.length === 0 ? (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
+              <p className="text-gray-500">
+                {debts.length === 0
+                  ? 'No debts yet. Add one to get started.'
+                  : 'No debts match the selected filters.'}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {filteredDebts.map(debt => (
+                <div
+                  key={debt.id}
+                  className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden"
+                >
+                  {/* Debt Card Header */}
+                  <button
+                    onClick={() => setExpandedDebtId(expandedDebtId === debt.id ? null : debt.id)}
+                    className="w-full text-left p-4 hover:bg-gray-50 transition-colors touch-manipulation"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="font-semibold text-gray-900 truncate">{debt.title}</span>
+                          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[debt.status]}`}>
+                            {debt.status}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2 text-sm text-gray-600">
+                          <span>{getContactName(debt.contact_id)}</span>
+                          <span>·</span>
+                          <span className={debt.type === 'owed_to_me' ? 'text-green-600' : 'text-red-600'}>
+                            {debt.type === 'owed_to_me' ? 'Owed to me' : 'I owe'}
+                          </span>
+                          <span>·</span>
+                          <span>{formatDate(debt.created_at)}</span>
+                        </div>
+                      </div>
+                      <div className="text-right flex-shrink-0">
+                        <div className={`text-lg font-bold ${debt.type === 'owed_to_me' ? 'text-green-600' : 'text-red-600'}`}>
+                          {formatCurrency(Number(debt.amount), debt.currency)}
+                        </div>
+                        {debt.totalPaid > 0 && (
+                          <div className="text-xs text-gray-500">
+                            Paid: {formatCurrency(debt.totalPaid, debt.currency)}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    {/* Progress bar */}
+                    {debt.totalPaid > 0 && (
+                      <div className="mt-2 w-full bg-gray-200 rounded-full h-1.5">
+                        <div
+                          className={`h-1.5 rounded-full ${debt.status === 'settled' ? 'bg-green-500' : 'bg-blue-500'}`}
+                          style={{ width: `${Math.min(100, (debt.totalPaid / Number(debt.amount)) * 100)}%` }}
+                        ></div>
+                      </div>
+                    )}
+                  </button>
+
+                  {/* Expanded: Payments */}
+                  {expandedDebtId === debt.id && (
+                    <div className="border-t border-gray-200 p-4 bg-gray-50">
+                      {debt.description && (
+                        <p className="text-sm text-gray-600 mb-3">{debt.description}</p>
+                      )}
+
+                      <div className="flex items-center justify-between mb-3">
+                        <h4 className="text-sm font-semibold text-gray-700">
+                          Payments ({debt.payments.length})
+                        </h4>
+                        <div className="text-sm text-gray-600">
+                          {formatCurrency(debt.totalPaid, debt.currency)} of {formatCurrency(Number(debt.amount), debt.currency)}
+                          {debt.status !== 'settled' && (
+                            <span className="ml-1">
+                              ({formatCurrency(Number(debt.amount) - debt.totalPaid, debt.currency)} remaining)
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Payment list */}
+                      {debt.payments.length > 0 && (
+                        <div className="space-y-2 mb-3">
+                          {debt.payments.map(payment => (
+                            <div key={payment.id} className="flex items-center justify-between bg-white rounded-lg p-3 border border-gray-200">
+                              <div>
+                                <div className="text-sm font-medium text-gray-900">
+                                  {formatCurrency(Number(payment.amount), debt.currency)}
+                                </div>
+                                <div className="text-xs text-gray-500">
+                                  {formatDate(payment.payment_date)}
+                                  {payment.note && <span className="ml-1">· {payment.note}</span>}
+                                </div>
+                              </div>
+                              <button
+                                onClick={() => handleDeletePayment(payment.id)}
+                                className="text-red-500 hover:text-red-700 p-1 touch-manipulation min-h-[44px] min-w-[44px] flex items-center justify-center"
+                                title="Delete payment"
+                              >
+                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                </svg>
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Add Payment Form */}
+                      {debt.status !== 'settled' && (
+                        <>
+                          {addingPaymentForDebt === debt.id ? (
+                            <div className="bg-white rounded-lg p-3 border border-gray-200 space-y-3">
+                              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                                <div>
+                                  <label className="block text-xs font-medium text-gray-700 mb-1">Amount *</label>
+                                  <input
+                                    type="number"
+                                    step="0.01"
+                                    min="0.01"
+                                    max={Number(debt.amount) - debt.totalPaid}
+                                    value={paymentForm.amount}
+                                    onChange={(e) => setPaymentForm(prev => ({ ...prev, amount: e.target.value }))}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                                    placeholder="0.00"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-xs font-medium text-gray-700 mb-1">Date *</label>
+                                  <input
+                                    type="date"
+                                    value={paymentForm.paymentDate}
+                                    onChange={(e) => setPaymentForm(prev => ({ ...prev, paymentDate: e.target.value }))}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-xs font-medium text-gray-700 mb-1">Note</label>
+                                  <input
+                                    type="text"
+                                    value={paymentForm.note}
+                                    onChange={(e) => setPaymentForm(prev => ({ ...prev, note: e.target.value }))}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                                    placeholder="Optional note"
+                                  />
+                                </div>
+                              </div>
+                              <div className="flex gap-2">
+                                <button
+                                  onClick={() => handleAddPayment(debt.id)}
+                                  disabled={!paymentForm.amount || !paymentForm.paymentDate}
+                                  className="bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation min-h-[44px]"
+                                >
+                                  Add Payment
+                                </button>
+                                <button
+                                  onClick={() => {
+                                    setAddingPaymentForDebt(null);
+                                    setPaymentForm({ amount: '', paymentDate: new Date().toISOString().split('T')[0], note: '' });
+                                  }}
+                                  className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium touch-manipulation min-h-[44px]"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
+                            <div className="flex items-center gap-3">
+                              <button
+                                onClick={() => setAddingPaymentForDebt(debt.id)}
+                                className="text-emerald-600 hover:text-emerald-700 text-sm font-medium touch-manipulation min-h-[44px]"
+                              >
+                                + Add Payment
+                              </button>
+                              <button
+                                onClick={() => handleAddPayment(debt.id, Number(debt.amount) - debt.totalPaid)}
+                                className="text-blue-600 hover:text-blue-700 text-sm font-medium touch-manipulation min-h-[44px]"
+                              >
+                                Settle Full Amount ({formatCurrency(Number(debt.amount) - debt.totalPaid, debt.currency)})
+                              </button>
+                            </div>
+                          )}
+                        </>
+                      )}
+
+                      {/* Delete debt */}
+                      <div className="mt-3 pt-3 border-t border-gray-200">
+                        <button
+                          onClick={() => handleDeleteDebt(debt.id)}
+                          className="text-red-500 hover:text-red-700 text-sm font-medium touch-manipulation min-h-[44px]"
+                        >
+                          Delete Debt
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      ) : (
+        /* Summary View */
+        <div className="space-y-4">
+          {/* Overall totals */}
+          {summary.length > 0 && (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">Overall</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div>
+                  <div className="text-xs text-gray-500 mb-1">Total owed to me</div>
+                  <div className="text-lg font-bold text-green-600">
+                    {(() => {
+                      const byCurrency = new Map<string, number>();
+                      summary.forEach(s => {
+                        byCurrency.set(s.currency, (byCurrency.get(s.currency) || 0) + s.totalOwedToMe);
+                      });
+                      return Array.from(byCurrency.entries())
+                        .filter(([, v]) => v > 0)
+                        .map(([cur, val]) => formatCurrency(val, cur))
+                        .join(', ') || formatCurrency(0, defaultCurrency || 'USD');
+                    })()}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-gray-500 mb-1">Total I owe</div>
+                  <div className="text-lg font-bold text-red-600">
+                    {(() => {
+                      const byCurrency = new Map<string, number>();
+                      summary.forEach(s => {
+                        byCurrency.set(s.currency, (byCurrency.get(s.currency) || 0) + s.totalOwedByMe);
+                      });
+                      return Array.from(byCurrency.entries())
+                        .filter(([, v]) => v > 0)
+                        .map(([cur, val]) => formatCurrency(val, cur))
+                        .join(', ') || formatCurrency(0, defaultCurrency || 'USD');
+                    })()}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-gray-500 mb-1">Net balance</div>
+                  <div className={`text-lg font-bold ${
+                    summary.reduce((sum, s) => sum + s.netBalance, 0) >= 0 ? 'text-green-600' : 'text-red-600'
+                  }`}>
+                    {(() => {
+                      const byCurrency = new Map<string, number>();
+                      summary.forEach(s => {
+                        byCurrency.set(s.currency, (byCurrency.get(s.currency) || 0) + s.netBalance);
+                      });
+                      return Array.from(byCurrency.entries())
+                        .filter(([, v]) => v !== 0)
+                        .map(([cur, val]) => `${val >= 0 ? '+' : ''}${formatCurrency(val, cur)}`)
+                        .join(', ') || formatCurrency(0, defaultCurrency || 'USD');
+                    })()}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Per-contact cards */}
+          {summary.length === 0 ? (
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
+              <p className="text-gray-500">No active debts to summarize.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {summary.map(s => (
+                <div key={`${s.contactId}-${s.currency}`} className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+                  <div className="flex items-center justify-between mb-3">
+                    <h4 className="font-semibold text-gray-900">{s.contactName}</h4>
+                    <span className="text-xs text-gray-500">{s.currency}</span>
+                  </div>
+                  <div className="space-y-2">
+                    <div className="flex justify-between text-sm">
+                      <span className="text-gray-600">Owed to me</span>
+                      <span className="text-green-600 font-medium">{formatCurrency(s.totalOwedToMe, s.currency)}</span>
+                    </div>
+                    <div className="flex justify-between text-sm">
+                      <span className="text-gray-600">I owe</span>
+                      <span className="text-red-600 font-medium">{formatCurrency(s.totalOwedByMe, s.currency)}</span>
+                    </div>
+                    <div className="border-t border-gray-200 pt-2 flex justify-between text-sm font-semibold">
+                      <span className="text-gray-700">Net</span>
+                      <span className={s.netBalance >= 0 ? 'text-green-600' : 'text-red-600'}>
+                        {s.netBalance >= 0 ? '+' : ''}{formatCurrency(s.netBalance, s.currency)}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Add Debt Modal */}
+      {showAddModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg max-w-lg w-full p-6 max-h-[90vh] overflow-y-auto">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Add Debt</h3>
+
+            <div className="space-y-4">
+              {/* Type Toggle */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Type *</label>
+                <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setDebtForm(prev => ({ ...prev, type: 'owed_to_me' }))}
+                    className={`flex-1 px-4 py-2 text-sm font-medium touch-manipulation min-h-[44px] ${
+                      debtForm.type === 'owed_to_me'
+                        ? 'bg-green-600 text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    Owed to me
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDebtForm(prev => ({ ...prev, type: 'owed_by_me' }))}
+                    className={`flex-1 px-4 py-2 text-sm font-medium touch-manipulation min-h-[44px] ${
+                      debtForm.type === 'owed_by_me'
+                        ? 'bg-red-600 text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    I owe
+                  </button>
+                </div>
+              </div>
+
+              {/* Contact */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Contact *</label>
+                <select
+                  value={debtForm.contactId}
+                  onChange={(e) => setDebtForm(prev => ({ ...prev, contactId: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                >
+                  <option value="">Select a contact</option>
+                  {contacts.map(c => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
+                  ))}
+                </select>
+                {contacts.length === 0 && (
+                  <p className="text-xs text-amber-600 mt-1">No contacts yet. Add contacts in Settings first.</p>
+                )}
+              </div>
+
+              {/* Title */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Title *</label>
+                <input
+                  type="text"
+                  value={debtForm.title}
+                  onChange={(e) => setDebtForm(prev => ({ ...prev, title: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                  placeholder="e.g., Dinner split"
+                />
+              </div>
+
+              {/* Description */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <textarea
+                  value={debtForm.description}
+                  onChange={(e) => setDebtForm(prev => ({ ...prev, description: e.target.value }))}
+                  rows={2}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent resize-y"
+                  placeholder="Optional description"
+                />
+              </div>
+
+              {/* Amount + Currency */}
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Amount *</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0.01"
+                    value={debtForm.amount}
+                    onChange={(e) => setDebtForm(prev => ({ ...prev, amount: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                    placeholder="0.00"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Currency *</label>
+                  <select
+                    value={debtForm.currency}
+                    onChange={(e) => setDebtForm(prev => ({ ...prev, currency: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                  >
+                    {SUPPORTED_CURRENCIES.map(code => (
+                      <option key={code} value={code}>{CURRENCY_INFO[code].symbol} {code}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              {/* Currency Conversion Helper */}
+              <div className="border border-gray-200 rounded-lg">
+                <button
+                  type="button"
+                  onClick={() => setShowConversion(v => !v)}
+                  className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors touch-manipulation"
+                >
+                  <span>Convert from another currency</span>
+                  <span className="text-gray-400">{showConversion ? '\u25B2' : '\u25BC'}</span>
+                </button>
+                {showConversion && (
+                  <div className="px-4 pb-4 space-y-3 border-t border-gray-100">
+                    <p className="text-xs text-gray-500 pt-3">
+                      Enter an amount in a foreign currency to auto-fill the amount above in {debtForm.currency}.
+                    </p>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
+                      <div>
+                        <label className="block text-xs font-medium text-gray-600 mb-1">Paid in</label>
+                        <select
+                          value={convertFrom}
+                          onChange={e => setConvertFrom(e.target.value as SupportedCurrency)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500 text-base"
+                        >
+                          {SUPPORTED_CURRENCIES.filter(c => c !== debtForm.currency).map(c => (
+                            <option key={c} value={c}>{c}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-600 mb-1">Amount</label>
+                        <input
+                          type="number"
+                          min={0}
+                          step="0.01"
+                          value={convertAmount || ''}
+                          onChange={e => setConvertAmount(parseFloat(e.target.value) || 0)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500 text-base"
+                          placeholder="0.00"
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        onClick={handleConvert}
+                        disabled={convertAmount <= 0}
+                        className="px-4 py-2 bg-emerald-600 text-white rounded-md text-sm font-medium hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors touch-manipulation min-h-[44px]"
+                      >
+                        Convert
+                      </button>
+                    </div>
+                    {convertPreview && (
+                      <p className="text-xs text-emerald-700 bg-emerald-50 px-3 py-2 rounded-md">{convertPreview}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* Create Transaction Checkbox */}
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="createTransaction"
+                  checked={debtForm.createTransaction}
+                  onChange={(e) => setDebtForm(prev => ({ ...prev, createTransaction: e.target.checked }))}
+                  className="w-4 h-4 text-emerald-600 border-gray-300 rounded focus:ring-emerald-500"
+                />
+                <label htmlFor="createTransaction" className="text-sm text-gray-700">
+                  Also create as transaction
+                </label>
+              </div>
+
+              {/* Transaction fields (conditional) */}
+              {debtForm.createTransaction && (
+                <div className="space-y-3 pl-6 border-l-2 border-emerald-200">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Category *</label>
+                    <select
+                      value={debtForm.categoryId}
+                      onChange={(e) => setDebtForm(prev => ({ ...prev, categoryId: e.target.value }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                    >
+                      <option value="">Select category</option>
+                      {categories.map(c => (
+                        <option key={c.id} value={c.id}>{c.emoji} {c.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Account *</label>
+                    <select
+                      value={debtForm.accountId}
+                      onChange={(e) => setDebtForm(prev => ({ ...prev, accountId: e.target.value }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                    >
+                      <option value="">Select account</option>
+                      {accounts.map(a => (
+                        <option key={a.id} value={a.id}>{a.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Transaction Date *</label>
+                    <input
+                      type="date"
+                      value={debtForm.transactionDate}
+                      onChange={(e) => setDebtForm(prev => ({ ...prev, transactionDate: e.target.value }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="flex space-x-3 mt-6">
+              <button
+                onClick={handleCreateDebt}
+                disabled={
+                  !debtForm.contactId ||
+                  !debtForm.title.trim() ||
+                  !debtForm.amount ||
+                  (debtForm.createTransaction && (!debtForm.categoryId || !debtForm.accountId))
+                }
+                className="flex-1 bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 transition-colors duration-200 font-medium disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation min-h-[44px]"
+              >
+                Create
+              </button>
+              <button
+                onClick={() => setShowAddModal(false)}
+                className="flex-1 border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors duration-200 font-medium touch-manipulation min-h-[44px]"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/expense-tracker/ExpenseNavbar.tsx
+++ b/src/components/expense-tracker/ExpenseNavbar.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 
 interface ExpenseNavbarProps {
-  activeTab: 'add' | 'transactions' | 'dashboard' | 'converter' | 'settings';
-  onTabChange: (tab: 'add' | 'transactions' | 'dashboard' | 'converter' | 'settings') => void;
+  activeTab: 'add' | 'transactions' | 'dashboard' | 'converter' | 'debts' | 'settings';
+  onTabChange: (tab: 'add' | 'transactions' | 'dashboard' | 'converter' | 'debts' | 'settings') => void;
 }
 
 export function ExpenseNavbar({ activeTab, onTabChange }: ExpenseNavbarProps) {
@@ -20,7 +20,7 @@ export function ExpenseNavbar({ activeTab, onTabChange }: ExpenseNavbarProps) {
     }
   };
 
-  const handleTabChange = (tab: 'add' | 'transactions' | 'dashboard' | 'converter' | 'settings') => {
+  const handleTabChange = (tab: 'add' | 'transactions' | 'dashboard' | 'converter' | 'debts' | 'settings') => {
     onTabChange(tab);
     setIsMobileMenuOpen(false); // Close mobile menu when tab is selected
   };
@@ -35,6 +35,7 @@ export function ExpenseNavbar({ activeTab, onTabChange }: ExpenseNavbarProps) {
     { id: 'transactions' as const, label: 'Transactions' },
     { id: 'dashboard' as const, label: 'Dashboard' },
     { id: 'converter' as const, label: 'Converter' },
+    { id: 'debts' as const, label: 'Debts' },
     { id: 'settings' as const, label: 'Settings' },
   ];
 

--- a/src/components/expense-tracker/ExpenseSettings.tsx
+++ b/src/components/expense-tracker/ExpenseSettings.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { ExpenseCategoryService } from '../../services/expenseCategoryService';
 import { UserAccountService } from '../../services/userAccountService';
-import type { UserExpenseCategory, UserAccount } from '../../lib/supabase';
+import { UserContactService } from '../../services/userContactService';
+import type { UserExpenseCategory, UserAccount, UserContact } from '../../lib/supabase';
 import { useUserSettings } from '../../hooks/useUserSettings';
 import { SUPPORTED_CURRENCIES, CURRENCY_INFO } from '../../lib/currencies';
 import type { SupportedCurrency } from '../../lib/currencies';
@@ -9,6 +10,7 @@ import type { SupportedCurrency } from '../../lib/currencies';
 export function ExpenseSettings() {
   const [allCategories, setAllCategories] = useState<UserExpenseCategory[]>([]);
   const [userAccounts, setUserAccounts] = useState<UserAccount[]>([]);
+  const [userContacts, setUserContacts] = useState<UserContact[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const { defaultCurrency, updateDefaultCurrency, isLoading: isSettingsLoading } = useUserSettings();
@@ -17,20 +19,23 @@ export function ExpenseSettings() {
   // Modal states
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [showAccountModal, setShowAccountModal] = useState(false);
+  const [showContactModal, setShowContactModal] = useState(false);
   const [editingCategory, setEditingCategory] = useState<UserExpenseCategory | null>(null);
   const [editingAccount, setEditingAccount] = useState<UserAccount | null>(null);
+  const [editingContact, setEditingContact] = useState<UserContact | null>(null);
 
   // Dropdown states
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
 
   // Form states
   const [categoryForm, setCategoryForm] = useState({ name: '', emoji: '📝', color: '#6B7280' });
-  const [accountForm, setAccountForm] = useState({ 
-    name: '', 
-    type: 'bank' as 'bank' | 'cash' | 'credit_card' | 'investment' | 'other', 
+  const [accountForm, setAccountForm] = useState({
+    name: '',
+    type: 'bank' as 'bank' | 'cash' | 'credit_card' | 'investment' | 'other',
     color: '#6B7280',
-    description: '' 
+    description: ''
   });
+  const [contactForm, setContactForm] = useState({ name: '' });
 
   // Load data
   useEffect(() => {
@@ -64,13 +69,15 @@ export function ExpenseSettings() {
   const loadData = async () => {
       try {
         setIsLoading(true);
-        const [allCategoriesData, accounts] = await Promise.all([
+        const [allCategoriesData, accounts, contactsData] = await Promise.all([
           ExpenseCategoryService.getAllAvailableExpenseCategories(),
-          UserAccountService.getUserAccounts()
+          UserAccountService.getUserAccounts(),
+          UserContactService.getContacts()
         ]);
-        
+
         setAllCategories(allCategoriesData);
         setUserAccounts(accounts);
+        setUserContacts(contactsData);
     } catch (err) {
       console.error('Error loading settings data:', err);
       setError(err instanceof Error ? err.message : 'Failed to load settings');
@@ -178,6 +185,58 @@ export function ExpenseSettings() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete account');
     }
+  };
+
+  // Contact functions
+  const handleCreateContact = async () => {
+    try {
+      setError('');
+      await UserContactService.createContact({ name: contactForm.name });
+      setContactForm({ name: '' });
+      setShowContactModal(false);
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create contact');
+    }
+  };
+
+  const handleUpdateContact = async () => {
+    if (!editingContact) return;
+    try {
+      setError('');
+      await UserContactService.updateContact(editingContact.id, { name: contactForm.name });
+      setContactForm({ name: '' });
+      setEditingContact(null);
+      setShowContactModal(false);
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update contact');
+    }
+  };
+
+  const handleDeleteContact = async (contact: UserContact) => {
+    closeDropdown();
+    if (!confirm(`Are you sure you want to delete "${contact.name}"?`)) return;
+    try {
+      setError('');
+      await UserContactService.deleteContact(contact.id);
+      loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete contact');
+    }
+  };
+
+  const openContactModal = (contact?: UserContact) => {
+    closeDropdown();
+    if (contact) {
+      setEditingContact(contact);
+      setContactForm({ name: contact.name });
+    } else {
+      setEditingContact(null);
+      setContactForm({ name: '' });
+    }
+    setShowContactModal(true);
+    setError('');
   };
 
   const handleCurrencyChange = async (currency: SupportedCurrency) => {
@@ -413,6 +472,65 @@ export function ExpenseSettings() {
             ))}
           </div>
         </div>
+
+        {/* Contacts Section */}
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">Contacts</h3>
+            <button
+              onClick={() => openContactModal()}
+              className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors duration-200 text-sm font-medium"
+            >
+              Add Contact
+            </button>
+          </div>
+
+          {userContacts.length === 0 ? (
+            <p className="text-sm text-gray-500">No contacts yet. Add contacts to use with the Debts tracker.</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {userContacts.map((contact) => (
+                <div
+                  key={contact.id}
+                  className="border-2 rounded-lg p-4 transition-all hover:shadow-lg bg-gray-600 border-gray-600"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-2">
+                      <span className="text-lg">👤</span>
+                      <span className="font-medium text-white text-shadow">{contact.name}</span>
+                    </div>
+                    <div className="dropdown-container relative">
+                      <button
+                        onClick={() => toggleDropdown(`contact-${contact.id}`)}
+                        className="text-white hover:text-gray-200 p-2 rounded-full bg-black bg-opacity-20 hover:bg-opacity-40 transition-all shadow-sm"
+                      >
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+                        </svg>
+                      </button>
+                      {openDropdown === `contact-${contact.id}` && (
+                        <div className="absolute right-0 top-8 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-10 min-w-[120px]">
+                          <button
+                            onClick={() => openContactModal(contact)}
+                            className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => handleDeleteContact(contact)}
+                            className="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Category Modal */}
@@ -588,6 +706,48 @@ export function ExpenseSettings() {
               </button>
               <button
                 onClick={() => setShowAccountModal(false)}
+                className="flex-1 border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors duration-200 font-medium"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Contact Modal */}
+      {showContactModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg max-w-md w-full p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">
+              {editingContact ? 'Edit Contact' : 'Add Contact'}
+            </h3>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Contact Name *
+                </label>
+                <input
+                  type="text"
+                  value={contactForm.name}
+                  onChange={(e) => setContactForm(prev => ({ ...prev, name: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                  placeholder="e.g., John Doe"
+                />
+              </div>
+            </div>
+
+            <div className="flex space-x-3 mt-6">
+              <button
+                onClick={editingContact ? handleUpdateContact : handleCreateContact}
+                disabled={!contactForm.name.trim()}
+                className="flex-1 bg-indigo-600 text-white py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors duration-200 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {editingContact ? 'Update' : 'Create'}
+              </button>
+              <button
+                onClick={() => setShowContactModal(false)}
                 className="flex-1 border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors duration-200 font-medium"
               >
                 Cancel

--- a/src/components/expense-tracker/ExpenseTracker.tsx
+++ b/src/components/expense-tracker/ExpenseTracker.tsx
@@ -8,9 +8,10 @@ import { Transactions } from './Transactions';
 import { ExpenseDashboard } from './ExpenseDashboard';
 import { ExpenseSettings } from './ExpenseSettings';
 import { CurrencyConverter } from './CurrencyConverter';
+import { DebtTracker } from './DebtTracker';
 
 export function ExpenseTracker() {
-  const [activeTab, setActiveTab] = useState<'add' | 'transactions' | 'dashboard' | 'converter' | 'settings'>('add');
+  const [activeTab, setActiveTab] = useState<'add' | 'transactions' | 'dashboard' | 'converter' | 'debts' | 'settings'>('add');
   const [isEmailVerification, setIsEmailVerification] = useState(false);
 
   useEffect(() => {
@@ -66,6 +67,7 @@ export function ExpenseTracker() {
             {activeTab === 'transactions' && <Transactions />}
             {activeTab === 'dashboard' && <ExpenseDashboard />}
             {activeTab === 'converter' && <CurrencyConverter />}
+            {activeTab === 'debts' && <DebtTracker />}
             {activeTab === 'settings' && <ExpenseSettings />}
           </main>
         </div>

--- a/src/components/shared/OfflineIndicator.tsx
+++ b/src/components/shared/OfflineIndicator.tsx
@@ -3,8 +3,10 @@ import { useNetworkStatus } from '../../hooks/useNetworkStatus';
 import { offlineQueue } from '../../services/offlineQueueService';
 import { TransactionService } from '../../services/transactionService';
 import { TimeEntryService } from '../../services/timeEntryService';
+import { DebtService } from '../../services/debtService';
 import type { CreateTransactionData } from '../../services/transactionService';
 import type { ManualTimeEntryData } from '../../services/timeEntryService';
+import type { CreateDebtData, CreateDebtTransactionData } from '../../services/debtService';
 
 /**
  * Interface for serialized time entry data from the offline queue.
@@ -68,6 +70,18 @@ export function OfflineIndicator() {
               await TimeEntryService.createManualEntry(deserializedData);
             }
             // Add update/delete handling as needed
+          } else if (operation.type === 'debt') {
+            if (operation.action === 'create') {
+              const debtData = operation.data as unknown as CreateDebtData & {
+                createTransaction?: boolean;
+                transactionData?: CreateDebtTransactionData;
+              };
+              const { createTransaction, transactionData, ...data } = debtData;
+              await DebtService.createDebt(
+                data,
+                createTransaction ? transactionData : undefined
+              );
+            }
           }
 
           await offlineQueue.removeFromQueue(operation.id);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -97,6 +97,40 @@ export interface ExchangeRate {
   updated_at: string;
 }
 
+// Debt tracking types
+export interface UserContact {
+  id: string;
+  user_id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Debt {
+  id: string;
+  user_id: string;
+  contact_id: string;
+  type: 'owed_to_me' | 'owed_by_me';
+  title: string;
+  description?: string;
+  amount: number;
+  currency: string;
+  transaction_id?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DebtPayment {
+  id: string;
+  user_id: string;
+  debt_id: string;
+  amount: number;
+  payment_date: string;
+  note?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 // Flashcard types
 export type FlashcardCardType = 'basic' | 'reversible' | 'cloze';
 export type FlashcardTheme = 'light' | 'dark' | 'system';

--- a/src/services/debtService.ts
+++ b/src/services/debtService.ts
@@ -1,0 +1,336 @@
+import { supabase } from '../lib/supabase';
+import { TransactionService } from './transactionService';
+import { offlineQueue } from './offlineQueueService';
+import type { Debt, DebtPayment } from '../lib/supabase';
+
+export interface CreateDebtData {
+  contactId: string;
+  type: 'owed_to_me' | 'owed_by_me';
+  title: string;
+  description?: string;
+  amount: number;
+  currency: string;
+}
+
+export interface CreateDebtTransactionData {
+  categoryId: string;
+  accountId: string;
+  transactionDate: string;
+}
+
+export interface AddPaymentData {
+  amount: number;
+  paymentDate: string;
+  note?: string;
+}
+
+export type DebtStatus = 'pending' | 'partial' | 'settled';
+
+export interface DebtWithPayments extends Debt {
+  payments: DebtPayment[];
+  status: DebtStatus;
+  totalPaid: number;
+}
+
+export interface ContactDebtSummary {
+  contactId: string;
+  contactName: string;
+  totalOwedToMe: number;
+  totalOwedByMe: number;
+  netBalance: number;
+  currency: string;
+}
+
+export function computeDebtStatus(amount: number, totalPaid: number): DebtStatus {
+  if (totalPaid <= 0) return 'pending';
+  if (totalPaid >= amount) return 'settled';
+  return 'partial';
+}
+
+export class DebtService {
+  static async createDebt(
+    data: CreateDebtData,
+    transactionData?: CreateDebtTransactionData
+  ): Promise<Debt> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to create debts');
+    }
+
+    let transactionId: string | undefined;
+
+    // Optionally create a linked transaction
+    if (transactionData) {
+      const txnType = data.type === 'owed_by_me' ? 'expense' : 'income';
+      const transaction = await TransactionService.createTransaction({
+        type: txnType as 'income' | 'expense',
+        amount: data.amount,
+        currency: data.currency,
+        categoryId: transactionData.categoryId,
+        accountId: transactionData.accountId,
+        title: data.title,
+        description: data.description,
+        transactionDate: transactionData.transactionDate,
+      });
+      transactionId = transaction.id;
+    }
+
+    const { data: debt, error } = await supabase
+      .from('debts')
+      .insert({
+        user_id: user.id,
+        contact_id: data.contactId,
+        type: data.type,
+        title: data.title,
+        description: data.description,
+        amount: data.amount,
+        currency: data.currency,
+        transaction_id: transactionId,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating debt:', error);
+      throw new Error(`Failed to create debt: ${error.message}`);
+    }
+
+    return debt;
+  }
+
+  static async createDebtOfflineAware(
+    data: CreateDebtData,
+    transactionData?: CreateDebtTransactionData
+  ): Promise<{ debt: Debt | null; isPending: boolean }> {
+    if (navigator.onLine) {
+      try {
+        const debt = await this.createDebt(data, transactionData);
+        return { debt, isPending: false };
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('network')) {
+          await offlineQueue.addToQueue('debt', 'create', {
+            ...data,
+            createTransaction: !!transactionData,
+            transactionData,
+          } as unknown as Record<string, unknown>);
+          return { debt: null, isPending: true };
+        }
+        throw error;
+      }
+    }
+
+    await offlineQueue.addToQueue('debt', 'create', {
+      ...data,
+      createTransaction: !!transactionData,
+      transactionData,
+    } as unknown as Record<string, unknown>);
+    return { debt: null, isPending: true };
+  }
+
+  static async getDebts(): Promise<DebtWithPayments[]> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to fetch debts');
+    }
+
+    const { data: debts, error } = await supabase
+      .from('debts')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching debts:', error);
+      throw new Error(`Failed to fetch debts: ${error.message}`);
+    }
+
+    if (!debts || debts.length === 0) return [];
+
+    // Fetch all payments for these debts
+    const debtIds = debts.map(d => d.id);
+    const { data: payments, error: paymentsError } = await supabase
+      .from('debt_payments')
+      .select('*')
+      .eq('user_id', user.id)
+      .in('debt_id', debtIds)
+      .order('payment_date', { ascending: false });
+
+    if (paymentsError) {
+      console.error('Error fetching debt payments:', paymentsError);
+      throw new Error(`Failed to fetch debt payments: ${paymentsError.message}`);
+    }
+
+    const paymentsByDebt = new Map<string, DebtPayment[]>();
+    for (const payment of (payments || [])) {
+      const existing = paymentsByDebt.get(payment.debt_id) || [];
+      existing.push(payment);
+      paymentsByDebt.set(payment.debt_id, existing);
+    }
+
+    return debts.map(debt => {
+      const debtPayments = paymentsByDebt.get(debt.id) || [];
+      const totalPaid = debtPayments.reduce((sum, p) => sum + Number(p.amount), 0);
+      return {
+        ...debt,
+        payments: debtPayments,
+        status: computeDebtStatus(Number(debt.amount), totalPaid),
+        totalPaid,
+      };
+    });
+  }
+
+  static async deleteDebt(debtId: string): Promise<void> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to delete debts');
+    }
+
+    const { error } = await supabase
+      .from('debts')
+      .delete()
+      .eq('id', debtId)
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Error deleting debt:', error);
+      throw new Error(`Failed to delete debt: ${error.message}`);
+    }
+  }
+
+  static async addPayment(debtId: string, data: AddPaymentData): Promise<DebtPayment> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to add payments');
+    }
+
+    // Validate payment doesn't exceed remaining amount
+    const { data: debt, error: debtError } = await supabase
+      .from('debts')
+      .select('amount')
+      .eq('id', debtId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (debtError || !debt) {
+      throw new Error('Debt not found');
+    }
+
+    const { data: existingPayments, error: paymentsError } = await supabase
+      .from('debt_payments')
+      .select('amount')
+      .eq('debt_id', debtId)
+      .eq('user_id', user.id);
+
+    if (paymentsError) {
+      throw new Error(`Failed to check existing payments: ${paymentsError.message}`);
+    }
+
+    const totalPaid = (existingPayments || []).reduce((sum, p) => sum + Number(p.amount), 0);
+    const remaining = Number(debt.amount) - totalPaid;
+
+    if (data.amount > remaining) {
+      throw new Error(`Payment amount (${data.amount}) exceeds remaining balance (${remaining.toFixed(2)})`);
+    }
+
+    const { data: payment, error } = await supabase
+      .from('debt_payments')
+      .insert({
+        user_id: user.id,
+        debt_id: debtId,
+        amount: data.amount,
+        payment_date: data.paymentDate,
+        note: data.note,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error adding payment:', error);
+      throw new Error(`Failed to add payment: ${error.message}`);
+    }
+
+    return payment;
+  }
+
+  static async deletePayment(paymentId: string): Promise<void> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to delete payments');
+    }
+
+    const { error } = await supabase
+      .from('debt_payments')
+      .delete()
+      .eq('id', paymentId)
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Error deleting payment:', error);
+      throw new Error(`Failed to delete payment: ${error.message}`);
+    }
+  }
+
+  static async getDebtSummaryByContact(): Promise<ContactDebtSummary[]> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to fetch debt summary');
+    }
+
+    // Get all debts with their payments
+    const debtsWithPayments = await this.getDebts();
+
+    // Get contacts for names
+    const { data: contacts, error: contactsError } = await supabase
+      .from('user_contacts')
+      .select('id, name')
+      .eq('user_id', user.id);
+
+    if (contactsError) {
+      throw new Error(`Failed to fetch contacts: ${contactsError.message}`);
+    }
+
+    const contactMap = new Map<string, string>();
+    for (const c of (contacts || [])) {
+      contactMap.set(c.id, c.name);
+    }
+
+    // Group by contact and currency
+    const summaryMap = new Map<string, ContactDebtSummary>();
+
+    for (const debt of debtsWithPayments) {
+      if (debt.status === 'settled') continue;
+
+      const remaining = Number(debt.amount) - debt.totalPaid;
+      const key = `${debt.contact_id}-${debt.currency}`;
+
+      if (!summaryMap.has(key)) {
+        summaryMap.set(key, {
+          contactId: debt.contact_id,
+          contactName: contactMap.get(debt.contact_id) || 'Unknown',
+          totalOwedToMe: 0,
+          totalOwedByMe: 0,
+          netBalance: 0,
+          currency: debt.currency,
+        });
+      }
+
+      const summary = summaryMap.get(key)!;
+      if (debt.type === 'owed_to_me') {
+        summary.totalOwedToMe += remaining;
+      } else {
+        summary.totalOwedByMe += remaining;
+      }
+      summary.netBalance = summary.totalOwedToMe - summary.totalOwedByMe;
+    }
+
+    return Array.from(summaryMap.values()).sort((a, b) =>
+      a.contactName.localeCompare(b.contactName)
+    );
+  }
+}

--- a/src/services/offlineQueueService.ts
+++ b/src/services/offlineQueueService.ts
@@ -9,7 +9,7 @@ const DB_VERSION = 1;
 const STORE_NAME = 'pending-operations';
 const MAX_RETRIES = 3;
 
-export type OperationType = 'transaction' | 'timeEntry';
+export type OperationType = 'transaction' | 'timeEntry' | 'debt';
 export type ActionType = 'create' | 'update' | 'delete';
 
 export interface QueuedOperation {

--- a/src/services/userContactService.ts
+++ b/src/services/userContactService.ts
@@ -1,0 +1,131 @@
+import { supabase } from '../lib/supabase';
+import type { UserContact } from '../lib/supabase';
+
+export interface CreateContactData {
+  name: string;
+}
+
+export interface UpdateContactData {
+  name: string;
+}
+
+export class UserContactService {
+  static async getContacts(): Promise<UserContact[]> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to access contacts');
+    }
+
+    const { data: contacts, error } = await supabase
+      .from('user_contacts')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('name');
+
+    if (error) {
+      console.error('Error fetching contacts:', error);
+      throw new Error(`Failed to fetch contacts: ${error.message}`);
+    }
+
+    return contacts || [];
+  }
+
+  static async createContact(data: CreateContactData): Promise<UserContact> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to create contacts');
+    }
+
+    const contacts = await this.getContacts();
+    const existing = contacts.find(c =>
+      c.name.toLowerCase() === data.name.trim().toLowerCase()
+    );
+
+    if (existing) {
+      throw new Error(`Contact "${data.name}" already exists`);
+    }
+
+    const { data: contact, error } = await supabase
+      .from('user_contacts')
+      .insert({
+        user_id: user.id,
+        name: data.name.trim(),
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating contact:', error);
+      throw new Error(`Failed to create contact: ${error.message}`);
+    }
+
+    return contact;
+  }
+
+  static async updateContact(contactId: string, data: UpdateContactData): Promise<UserContact> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to update contacts');
+    }
+
+    if (data.name) {
+      const contacts = await this.getContacts();
+      const existing = contacts.find(c =>
+        c.name.toLowerCase() === data.name.trim().toLowerCase() && c.id !== contactId
+      );
+
+      if (existing) {
+        throw new Error(`Contact "${data.name}" already exists`);
+      }
+    }
+
+    const { data: contact, error } = await supabase
+      .from('user_contacts')
+      .update({ name: data.name.trim() })
+      .eq('id', contactId)
+      .eq('user_id', user.id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating contact:', error);
+      throw new Error(`Failed to update contact: ${error.message}`);
+    }
+
+    return contact;
+  }
+
+  static async deleteContact(contactId: string): Promise<void> {
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('User must be authenticated to delete contacts');
+    }
+
+    // Check if contact is referenced by any debts
+    const { data: debts } = await supabase
+      .from('debts')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('contact_id', contactId)
+      .limit(1);
+
+    if (debts && debts.length > 0) {
+      throw new Error('Cannot delete contact that has associated debts');
+    }
+
+    const { error } = await supabase
+      .from('user_contacts')
+      .delete()
+      .eq('id', contactId)
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Error deleting contact:', error);
+      throw new Error(`Failed to delete contact: ${error.message}`);
+    }
+  }
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -57,7 +57,7 @@ const STORE_NAME = 'pending-operations';
 
 interface QueuedOperation {
   id: string;
-  type: 'transaction' | 'timeEntry';
+  type: 'transaction' | 'timeEntry' | 'debt';
   action: 'create' | 'update' | 'delete';
   data: Record<string, unknown>;
   timestamp: number;
@@ -158,6 +158,17 @@ async function processOperation(operation: QueuedOperation): Promise<void> {
   }
 
   if (operation.type === 'timeEntry' && operation.action === 'create') {
+    const clients = await self.clients.matchAll();
+    if (clients.length > 0) {
+      clients[0].postMessage({
+        type: 'PROCESS_QUEUED_OPERATION',
+        operation,
+      });
+    }
+    return;
+  }
+
+  if (operation.type === 'debt' && operation.action === 'create') {
     const clients = await self.clients.matchAll();
     if (clients.length > 0) {
       clients[0].postMessage({

--- a/supabase/migrations/037_create_user_contacts.sql
+++ b/supabase/migrations/037_create_user_contacts.sql
@@ -1,0 +1,47 @@
+-- User contacts for tracking debts/loans
+-- Users can create contacts to associate with debts
+
+CREATE TABLE IF NOT EXISTS user_contacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Unique constraint on contact name per user (case-insensitive)
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_contact_name
+  ON user_contacts(user_id, LOWER(name));
+
+-- Index for listing contacts by user
+CREATE INDEX IF NOT EXISTS idx_user_contacts_user ON user_contacts(user_id);
+
+-- RLS
+ALTER TABLE user_contacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own contacts" ON user_contacts
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own contacts" ON user_contacts
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own contacts" ON user_contacts
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own contacts" ON user_contacts
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION set_updated_at_user_contacts()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_user_contacts_updated_at ON user_contacts;
+CREATE TRIGGER trg_user_contacts_updated_at
+  BEFORE UPDATE ON user_contacts
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at_user_contacts();

--- a/supabase/migrations/038_create_debts.sql
+++ b/supabase/migrations/038_create_debts.sql
@@ -1,0 +1,51 @@
+-- Debts table for tracking money owed to/by the user
+-- Each debt is associated with a contact and optionally linked to a transaction
+
+CREATE TABLE IF NOT EXISTS debts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES user_contacts(id),
+  type TEXT NOT NULL CHECK (type IN ('owed_to_me', 'owed_by_me')),
+  title TEXT NOT NULL,
+  description TEXT,
+  amount DECIMAL(15,2) NOT NULL CHECK (amount > 0),
+  currency TEXT NOT NULL,
+  transaction_id UUID REFERENCES transactions(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_debts_user ON debts(user_id);
+CREATE INDEX IF NOT EXISTS idx_debts_contact ON debts(contact_id);
+CREATE INDEX IF NOT EXISTS idx_debts_type ON debts(user_id, type);
+
+-- RLS
+ALTER TABLE debts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own debts" ON debts
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own debts" ON debts
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own debts" ON debts
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own debts" ON debts
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION set_updated_at_debts()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_debts_updated_at ON debts;
+CREATE TRIGGER trg_debts_updated_at
+  BEFORE UPDATE ON debts
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at_debts();

--- a/supabase/migrations/039_create_debt_payments.sql
+++ b/supabase/migrations/039_create_debt_payments.sql
@@ -1,0 +1,47 @@
+-- Debt payments table for tracking partial/full payments on debts
+-- Currency always matches the parent debt's currency
+
+CREATE TABLE IF NOT EXISTS debt_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  debt_id UUID NOT NULL REFERENCES debts(id) ON DELETE CASCADE,
+  amount DECIMAL(15,2) NOT NULL CHECK (amount > 0),
+  payment_date DATE NOT NULL,
+  note TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_debt_payments_user ON debt_payments(user_id);
+CREATE INDEX IF NOT EXISTS idx_debt_payments_debt ON debt_payments(debt_id);
+
+-- RLS
+ALTER TABLE debt_payments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own debt payments" ON debt_payments
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own debt payments" ON debt_payments
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own debt payments" ON debt_payments
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own debt payments" ON debt_payments
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION set_updated_at_debt_payments()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_debt_payments_updated_at ON debt_payments;
+CREATE TRIGGER trg_debt_payments_updated_at
+  BEFORE UPDATE ON debt_payments
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at_debt_payments();


### PR DESCRIPTION
## Summary
- Add debt/loan tracking system as a new "Debts" tab in the expense tracker
- Contacts management in Settings for associating debts with people
- Full payment lifecycle with auto-calculated status (pending/partial/settled)
- Currency conversion support when creating debts
- Quick "Settle Full Amount" button for one-click debt settlement
- Optional linked transaction creation when adding debts
- Offline support for debt creation via existing queue infrastructure
- 3 new database migrations: user_contacts, debts, debt_payments (all with RLS)

## Test plan
- [ ] Create contacts in Settings, verify edit/delete with in-use protection
- [ ] Create debts (owed to me / I owe) with and without linked transactions
- [ ] Add partial payments, verify status transitions (pending -> partial -> settled)
- [ ] Use "Settle Full Amount" quick button, verify debt becomes settled
- [ ] Test currency conversion in the Add Debt modal
- [ ] Switch to Summary view, verify per-contact net balances
- [ ] Test filters (type + status) in list view
- [ ] Verify offline debt creation queues and syncs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)