### PR TITLE
Redesign landing page grid for desktop

### DIFF
--- a/src/components/shared/LandingPage.tsx
+++ b/src/components/shared/LandingPage.tsx
@@ -2,6 +2,49 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useEffect } from 'react';
 
+const apps = [
+  {
+    name: 'Hobby Tracker',
+    emoji: '🎯',
+    description: 'Track your hobbies & activities',
+    route: '/hobby-tracker',
+    color: 'bg-indigo-600 hover:bg-indigo-700',
+    buttonText: 'Start Tracking',
+  },
+  {
+    name: 'Expense Tracker',
+    emoji: '💰',
+    description: 'Monitor spending & expenses',
+    route: '/expense-tracker',
+    color: 'bg-green-600 hover:bg-green-700',
+    buttonText: 'Track Expenses',
+  },
+  {
+    name: 'Music Tools',
+    emoji: '🎵',
+    description: 'Audio utilities & practice aids',
+    route: '/music-tools',
+    color: 'bg-purple-600 hover:bg-purple-700',
+    buttonText: 'Explore Tools',
+  },
+  {
+    name: 'Chat',
+    emoji: '💬',
+    description: 'Chat interface & messaging',
+    route: '/chat',
+    color: 'bg-cyan-600 hover:bg-cyan-700',
+    buttonText: 'Start Chatting',
+  },
+  {
+    name: 'Flashcards',
+    emoji: '🧠',
+    description: 'Spaced repetition learning',
+    route: '/flashcards',
+    color: 'bg-amber-600 hover:bg-amber-700',
+    buttonText: 'Start Learning',
+  },
+];
+
 export function LandingPage() {
   const navigate = useNavigate();
   const { user, loading } = useAuth();
@@ -13,7 +56,7 @@ export function LandingPage() {
       const hashParams = new URLSearchParams(hash.substring(1));
       const type = hashParams.get('type');
       const accessToken = hashParams.get('access_token');
-      
+
       // If this is an email verification callback, redirect to verification handler
       if (type === 'signup' && accessToken) {
         navigate('/verify-email');
@@ -24,194 +67,75 @@ export function LandingPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <div className="max-w-lg md:max-w-4xl mx-auto px-4 sm:px-6 pt-8 sm:pt-12 md:flex md:items-center md:justify-center md:min-h-screen md:pt-0 text-center">
-        <div className="md:w-full">
-          <div className="mb-6 sm:mb-8 md:mb-12">
-            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 mb-3 md:mb-4">
-              Welcome to <span className="text-indigo-600">Tool Hub</span>
-            </h1>
-            
-            {/* Authentication Status */}
-            <div className="mb-4">
-              {loading ? (
-                <p className="text-sm text-gray-500">Loading...</p>
-              ) : user ? (
-                <div className="space-y-2">
-                  <p className="text-sm text-gray-700">
-                    Currently signed in as <span className="font-medium">{user.email}</span>
-                  </p>
-                  <button
-                    onClick={() => navigate('/account')}
-                    className="text-sm text-indigo-600 hover:text-indigo-700 underline transition-colors"
-                  >
-                    Manage Account
-                  </button>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <p className="text-sm text-gray-600">Currently not signed in</p>
-                  <button
-                    onClick={() => navigate('/signin')}
-                    className="text-sm text-indigo-600 hover:text-indigo-700 underline transition-colors"
-                  >
-                    Sign in?
-                  </button>
-                </div>
-              )}
-            </div>
-            
-            <p className="text-base sm:text-lg md:text-xl text-gray-600 md:max-w-2xl md:mx-auto">
-              <span className="md:hidden">Your everyday tools and experiments</span>
-              <span className="hidden md:inline">A personal hub for everyday tools — track hobbies, manage expenses — and a sandbox to build, try, and deploy new experiments</span>
-            </p>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 pt-8 sm:pt-12 md:pt-16 pb-8 text-center">
+        <div className="mb-6 sm:mb-8 md:mb-12">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 mb-3 md:mb-4">
+            Welcome to <span className="text-indigo-600">Tool Hub</span>
+          </h1>
+
+          {/* Authentication Status */}
+          <div className="mb-4">
+            {loading ? (
+              <p className="text-sm text-gray-500">Loading...</p>
+            ) : user ? (
+              <div className="space-y-2">
+                <p className="text-sm text-gray-700">
+                  Currently signed in as <span className="font-medium">{user.email}</span>
+                </p>
+                <button
+                  onClick={() => navigate('/account')}
+                  className="text-sm text-indigo-600 hover:text-indigo-700 underline transition-colors"
+                >
+                  Manage Account
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-sm text-gray-600">Currently not signed in</p>
+                <button
+                  onClick={() => navigate('/signin')}
+                  className="text-sm text-indigo-600 hover:text-indigo-700 underline transition-colors"
+                >
+                  Sign in?
+                </button>
+              </div>
+            )}
           </div>
 
-          {/* Mobile-first two-column grid - visible only on mobile */}
-          <div className="grid grid-cols-2 gap-4 sm:gap-6 mb-6 sm:mb-8 md:hidden">
-            {/* Hobby Tracker Button */}
+          <p className="text-base sm:text-lg md:text-xl text-gray-600 max-w-2xl mx-auto">
+            <span className="md:hidden">Your everyday tools and experiments</span>
+            <span className="hidden md:inline">A personal hub for everyday tools — track hobbies, manage expenses — and a sandbox to build, try, and deploy new experiments</span>
+          </p>
+        </div>
+
+        {/* Responsive grid: 2 cols mobile, 3 cols desktop */}
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 sm:gap-5 md:gap-6 mb-8">
+          {apps.map((app) => (
             <button
-              onClick={() => navigate('/hobby-tracker')}
-              className="bg-white rounded-xl shadow-lg p-4 sm:p-6 hover:shadow-xl transition-all duration-300 hover:scale-105 active:scale-95 touch-manipulation min-h-[120px] sm:min-h-[140px] flex flex-col items-center justify-center group"
+              key={app.route}
+              onClick={() => navigate(app.route)}
+              className="bg-white rounded-xl shadow-lg p-4 sm:p-5 md:p-6 hover:shadow-xl transition-all duration-300 hover:scale-[1.03] active:scale-95 touch-manipulation flex flex-col items-center text-center group"
             >
-              <div className="text-2xl sm:text-3xl mb-2 group-hover:scale-110 transition-transform duration-200">🎯</div>
-              <h2 className="text-sm sm:text-lg font-semibold text-gray-900 mb-1 sm:mb-2">Hobby Tracker</h2>
-              <p className="text-xs sm:text-sm text-gray-600 text-center leading-tight">
-                Track your hobbies & activities
+              <div className="text-2xl sm:text-3xl md:text-4xl mb-2 md:mb-3 group-hover:scale-110 transition-transform duration-200">
+                {app.emoji}
+              </div>
+              <h2 className="text-sm sm:text-base md:text-lg font-semibold text-gray-900 mb-1 md:mb-2">
+                {app.name}
+              </h2>
+              <p className="text-xs sm:text-sm text-gray-600 leading-tight mb-3 md:mb-4 flex-1">
+                {app.description}
               </p>
+              <span className={`hidden md:inline-block w-full ${app.color} text-white py-2 px-4 rounded-lg transition-colors duration-200 font-medium text-sm`}>
+                {app.buttonText}
+              </span>
             </button>
+          ))}
+        </div>
 
-            {/* Expense Tracker Button */}
-            <button
-              onClick={() => navigate('/expense-tracker')}
-              className="bg-white rounded-xl shadow-lg p-4 sm:p-6 hover:shadow-xl transition-all duration-300 hover:scale-105 active:scale-95 touch-manipulation min-h-[120px] sm:min-h-[140px] flex flex-col items-center justify-center group"
-            >
-              <div className="text-2xl sm:text-3xl mb-2 group-hover:scale-110 transition-transform duration-200">💰</div>
-              <h2 className="text-sm sm:text-lg font-semibold text-gray-900 mb-1 sm:mb-2">Expense Tracker</h2>
-              <p className="text-xs sm:text-sm text-gray-600 text-center leading-tight">
-                Monitor spending & expenses
-              </p>
-            </button>
-
-            {/* Music Tools Button */}
-            <button
-              onClick={() => navigate('/music-tools')}
-              className="bg-white rounded-xl shadow-lg p-4 sm:p-6 hover:shadow-xl transition-all duration-300 hover:scale-105 active:scale-95 touch-manipulation min-h-[120px] sm:min-h-[140px] flex flex-col items-center justify-center group"
-            >
-              <div className="text-2xl sm:text-3xl mb-2 group-hover:scale-110 transition-transform duration-200">🎵</div>
-              <h2 className="text-sm sm:text-lg font-semibold text-gray-900 mb-1 sm:mb-2">Music Tools</h2>
-              <p className="text-xs sm:text-sm text-gray-600 text-center leading-tight">
-                Audio utilities & practice aids
-              </p>
-            </button>
-
-            {/* Chat Button */}
-            <button
-              onClick={() => navigate('/chat')}
-              className="bg-white rounded-xl shadow-lg p-4 sm:p-6 hover:shadow-xl transition-all duration-300 hover:scale-105 active:scale-95 touch-manipulation min-h-[120px] sm:min-h-[140px] flex flex-col items-center justify-center group"
-            >
-              <div className="text-2xl sm:text-3xl mb-2 group-hover:scale-110 transition-transform duration-200">💬</div>
-              <h2 className="text-sm sm:text-lg font-semibold text-gray-900 mb-1 sm:mb-2">Chat</h2>
-              <p className="text-xs sm:text-sm text-gray-600 text-center leading-tight">
-                Chat interface & messaging
-              </p>
-            </button>
-
-            {/* Flashcards Button */}
-            <button
-              onClick={() => navigate('/flashcards')}
-              className="bg-white rounded-xl shadow-lg p-4 sm:p-6 hover:shadow-xl transition-all duration-300 hover:scale-105 active:scale-95 touch-manipulation min-h-[120px] sm:min-h-[140px] flex flex-col items-center justify-center group"
-            >
-              <div className="text-2xl sm:text-3xl mb-2 group-hover:scale-110 transition-transform duration-200">🧠</div>
-              <h2 className="text-sm sm:text-lg font-semibold text-gray-900 mb-1 sm:mb-2">Flashcards</h2>
-              <p className="text-xs sm:text-sm text-gray-600 text-center leading-tight">
-                Spaced repetition learning
-              </p>
-            </button>
-          </div>
-
-          {/* Desktop layout - visible only on medium screens and up */}
-          <div className="hidden md:grid md:grid-cols-5 gap-6 sm:gap-8 max-w-6xl mx-auto mb-8 sm:mb-12">
-            {/* Hobby Tracker Card */}
-            <div className="bg-white rounded-2xl shadow-lg p-6 sm:p-8 hover:shadow-xl transition-shadow duration-300 flex flex-col">
-              <div className="text-3xl sm:text-4xl mb-4">🎯</div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 mb-4">Hobby Tracker</h2>
-              <p className="text-sm sm:text-base text-gray-600 mb-6 flex-1">
-                Track your hobbies, analyze time spent on activities, and manage your personal interests efficiently
-              </p>
-              <button
-                onClick={() => navigate('/hobby-tracker')}
-                className="w-full bg-indigo-600 text-white py-3 px-6 rounded-lg hover:bg-indigo-700 transition-colors duration-200 font-medium touch-manipulation min-h-[44px] text-base sm:text-lg"
-              >
-                Start Hobby Tracking
-              </button>
-            </div>
-
-            {/* Expense Tracker Card */}
-            <div className="bg-white rounded-2xl shadow-lg p-6 sm:p-8 hover:shadow-xl transition-shadow duration-300 flex flex-col">
-              <div className="text-3xl sm:text-4xl mb-4">💰</div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 mb-4">Expense Tracker</h2>
-              <p className="text-sm sm:text-base text-gray-600 mb-6 flex-1">
-                Monitor your spending, categorize expenses, and gain insights into your financial habits
-              </p>
-              <button
-                onClick={() => navigate('/expense-tracker')}
-                className="w-full bg-green-600 text-white py-3 px-6 rounded-lg hover:bg-green-700 transition-colors duration-200 font-medium touch-manipulation min-h-[44px] text-base sm:text-lg"
-              >
-                Track Expenses
-              </button>
-            </div>
-
-            {/* Music Tools Card */}
-            <div className="bg-white rounded-2xl shadow-lg p-6 sm:p-8 hover:shadow-xl transition-shadow duration-300 flex flex-col">
-              <div className="text-3xl sm:text-4xl mb-4">🎵</div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 mb-4">Music Tools</h2>
-              <p className="text-sm sm:text-base text-gray-600 mb-6 flex-1">
-                Practice timers, metronome, and music-focused utilities
-              </p>
-              <button
-                onClick={() => navigate('/music-tools')}
-                className="w-full bg-purple-600 text-white py-3 px-6 rounded-lg hover:bg-purple-700 transition-colors duration-200 font-medium touch-manipulation min-h-[44px] text-base sm:text-lg"
-              >
-                Explore Music Tools
-              </button>
-            </div>
-
-            {/* Chat Card */}
-            <div className="bg-white rounded-2xl shadow-lg p-6 sm:p-8 hover:shadow-xl transition-shadow duration-300 flex flex-col">
-              <div className="text-3xl sm:text-4xl mb-4">💬</div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 mb-4">Chat</h2>
-              <p className="text-sm sm:text-base text-gray-600 mb-6 flex-1">
-                Chat interface for messaging and conversations
-              </p>
-              <button
-                onClick={() => navigate('/chat')}
-                className="w-full bg-cyan-600 text-white py-3 px-6 rounded-lg hover:bg-cyan-700 transition-colors duration-200 font-medium touch-manipulation min-h-[44px] text-base sm:text-lg"
-              >
-                Start Chatting
-              </button>
-            </div>
-
-            {/* Flashcards Card */}
-            <div className="bg-white rounded-2xl shadow-lg p-6 sm:p-8 hover:shadow-xl transition-shadow duration-300 flex flex-col">
-              <div className="text-3xl sm:text-4xl mb-4">🧠</div>
-              <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 mb-4">Flashcards</h2>
-              <p className="text-sm sm:text-base text-gray-600 mb-6 flex-1">
-                Spaced repetition flashcards for effective memorization and learning
-              </p>
-              <button
-                onClick={() => navigate('/flashcards')}
-                className="w-full bg-amber-600 text-white py-3 px-6 rounded-lg hover:bg-amber-700 transition-colors duration-200 font-medium touch-manipulation min-h-[44px] text-base sm:text-lg"
-              >
-                Start Learning
-              </button>
-            </div>
-          </div>
-
-          <div className="text-gray-500">
-            <p className="text-xs sm:text-sm md:text-base">Choose your tool and start being more productive today</p>
-          </div>
+        <div className="text-gray-500">
+          <p className="text-xs sm:text-sm md:text-base">Choose your tool and start being more productive today</p>
         </div>
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- Replace cramped 5-column desktop grid (`md:grid-cols-5`) with a responsive 3-column layout (`md:grid-cols-3`) that gives cards proper width
- Unify duplicate mobile/desktop card sections into a single data-driven grid rendered from an `apps` array
- Wider container (`max-w-5xl`) so columns have room to breathe and text fits naturally

## Test plan
- [ ] Verify desktop layout shows 3 columns with readable card text
- [ ] Verify mobile layout still shows 2 columns
- [ ] Verify all 5 app cards navigate to correct routes
- [ ] Verify colored CTA buttons appear on desktop only
- [ ] Check that adding a 6th app to the array renders correctly in a new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)